### PR TITLE
Add Pre-shared key support for wireguard-initramfs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ install: remove_legacy
 	@mkdir -p "$(TARGETDIR)"
 	@touch "$(TARGETDIR)/private_key"
 	@chmod 0600 "$(TARGETDIR)/private_key"
+	@touch "$(TARGETDIR)/pre_shared_key"
+	@chmod 0600 "$(TARGETDIR)/pre_shared_key"
 	@cp -vn config "$(TARGETDIR)/config"
 	@chmod 0644 "$(TARGETDIR)/config"
 	@cp -v hooks "$(INITRAMFS)/hooks/wireguard"

--- a/config
+++ b/config
@@ -25,6 +25,9 @@ INTERFACE_ADDR=172.31.255.10/32
 # Peer public key (server's public key).
 PEER_PUBLIC_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+# Pre shared key (optional: leave blank to disable).
+PRE_SHARED_KEY=/etc/wireguard-initramfs/pre_shared_key
+
 # IP:PORT of the peer (server); any reachable IP/DNS.
 PEER_ENDPOINT=wg.example.com:51820
 

--- a/hooks
+++ b/hooks
@@ -27,6 +27,10 @@ if [ ! -s "${CLIENT_PRIVATE_KEYFILE}" ]; then
   echo "Wireguard client private key required. Missing: ${CLIENT_PRIVATE_KEYFILE}"
   return 1
 fi
+if [ ! -z ${PRE_SHARED_KEY} ] && [ ! -s "${PRE_SHARED_KEY}" ]; then
+  echo "Wireguard client pre shared key required. Missing: ${PRE_SHARED_KEY}"
+  return 1
+fi
 
 # Copy latest versions of shared objects needed for DNS resolution
 for so in $(ldconfig -p | sed -nr 's/^\s*libnss_files\.so\.[0-9]+\s.*=>\s*//p'); do
@@ -40,6 +44,9 @@ done
 mkdir -p -- "${DESTDIR}/etc/wireguard"
 cp -p "${CONFIG}" "${DESTDIR}/etc/wireguard"
 cp -p "${CLIENT_PRIVATE_KEYFILE}" "${DESTDIR}/etc/wireguard/private_key"
+if [ ! -z ${PRE_SHARED_KEY} ]; then                                                      │
+  cp -p "${PRE_SHARED_KEY}" "${DESTDIR}/etc/wireguard/pre_shared_key"                    │
+fi
 
 # Add modules and wireguard exec
 manual_add_modules wireguard

--- a/init-premount
+++ b/init-premount
@@ -46,6 +46,11 @@ if [ -z ${PEER_PUBLIC_KEY} ]; then
   return 1
 fi
 
+if [ ! -z ${PRE_SHARED_KEY} ] && [ ! -s "/etc/wireguard/pre_shared_key" ]; then
+  log_failure_msg 'Pre shared key is not defined'
+  return 1
+fi
+
 if [ -z ${PEER_ENDPOINT} ]; then
   log_failure_msg 'Peer endpoint is not defined'
   return 1
@@ -78,12 +83,23 @@ for adapter in /run/net-*.conf; do
 done
 
 ip link add dev ${INTERFACE} type wireguard
+
+if [ -z ${PRE_SHARED_KEY} ]; then
 /sbin/wg set ${INTERFACE} \
     private-key /etc/wireguard/private_key \
     peer ${PEER_PUBLIC_KEY} \
     endpoint ${PEER_ENDPOINT} \
     persistent-keepalive ${PERSISTENT_KEEPALIVES} \
     allowed-ips ${ALLOWED_IPS}
+else
+/sbin/wg set ${INTERFACE} \
+    private-key /etc/wireguard/private_key \
+    preshared-key /etc/wireguard/pre_shared_key \
+    peer ${PEER_PUBLIC_KEY} \
+    endpoint ${PEER_ENDPOINT} \
+    persistent-keepalive ${PERSISTENT_KEEPALIVES} \
+    allowed-ips ${ALLOWED_IPS}
+fi
 ip addr add ${INTERFACE_ADDR} dev ${INTERFACE}
 ip link set ${INTERFACE} up
 ip route add ${ALLOWED_IPS} dev ${INTERFACE}


### PR DESCRIPTION
Added:
* 'preshared-key' optional support for wireguard. This will only be activated if the PRE_SHARED_KEY option in the config is defined.

Fixes #10