### PR TITLE
FIX: Validate DNS exist before adding them

### DIFF
--- a/init-premount
+++ b/init-premount
@@ -74,16 +74,16 @@ touch /etc/resolv.conf
 for adapter in /run/net-*.conf; do
   . "${adapter}"
   if [ ! -z "${IPV4DNS0}" ]; then
-    echo nameserver "${IPV4DNS0}" >> /etc/resolv.conf
+    echo "nameserver ${IPV4DNS0}" >> /etc/resolv.conf
   fi
-  if [ ! -z "${IPV4DNS1}" ]; then;
-    echo nameserver "${IPV4DNS1}" >> /etc/resolv.conf
+  if [ ! -z "${IPV4DNS1}" ]; then
+    echo "nameserver ${IPV4DNS1}" >> /etc/resolv.conf
   fi
   if [ ! -z "${IPV6DNS0}" ]; then
-    echo nameserver "${IPV6DNS0}" >> /etc/resolv.conf
+    echo "nameserver ${IPV6DNS0}" >> /etc/resolv.conf
   fi
   if [ ! -z "${IPV6DNS1}" ]; then
-    echo nameserver "${IPV6DNS1}" >> /etc/resolv.conf
+    echo "nameserver ${IPV6DNS1}" >> /etc/resolv.conf
   fi
 done
 

--- a/init-premount
+++ b/init-premount
@@ -75,10 +75,15 @@ for adapter in /run/net-*.conf; do
   . "${adapter}"
   if [ ! -z "${IPV4DNS0}" ]; then
     echo nameserver "${IPV4DNS0}" >> /etc/resolv.conf
+  fi
+  if [ ! -z "${IPV4DNS1}" ]; then;
     echo nameserver "${IPV4DNS1}" >> /etc/resolv.conf
   fi
   if [ ! -z "${IPV6DNS0}" ]; then
     echo nameserver "${IPV6DNS0}" >> /etc/resolv.conf
+  fi
+  if [ ! -z "${IPV6DNS1}" ]; then
+    echo nameserver "${IPV6DNS1}" >> /etc/resolv.conf
   fi
 done
 


### PR DESCRIPTION
Validate both primary and secondary DNS servers for IPv4 and IPv6 exist prior to adding them to resolv.conf