### PR TITLE
FEATURE: Leave wireguard interface up

### DIFF
--- a/config
+++ b/config
@@ -39,3 +39,6 @@ PERSISTENT_KEEPALIVES=25
 
 # Allowed IP's (CIDR) on wireguard; for boot this should be the peer (server).
 ALLOWED_IPS=172.31.255.254/32
+
+# If PERSISTENT is set to any non-null value, the wireguard interface will be left up after initramfs exits
+PERSISTENT=Y

--- a/config
+++ b/config
@@ -41,4 +41,4 @@ PERSISTENT_KEEPALIVES=25
 ALLOWED_IPS=172.31.255.254/32
 
 # If PERSISTENT is set to any non-null value, the wireguard interface will be left up after initramfs exits
-PERSISTENT=Y
+#PERSISTENT=Y

--- a/init-bottom
+++ b/init-bottom
@@ -17,6 +17,8 @@ esac
 
 . /etc/wireguard/config
 
-log_begin_msg 'Stopping wireguard boot network'
-ip link delete dev ${INTERFACE}
+if [ -z "${PERSISTENT}" ]; then
+	log_begin_msg 'Stopping wireguard boot network'
+	ip link delete dev ${INTERFACE}
+fi
 log_end_msg


### PR DESCRIPTION
New config item PERSISTENT. If PERSISTENT is not null, the wireguard interface will be left up after the initramfs exits.