### PR TITLE
Some enhancements for the Makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,16 +35,10 @@ install_files:
 	@chmod 0600 "$(TARGETDIR)/pre_shared_key"
 	@cp -vn config "$(TARGETDIR)/config"
 	@chmod 0644 "$(TARGETDIR)/config"
-	@cp -v hooks "$(INITRAMFS)/hooks/wireguard"
-	@chmod 0755 hooks "$(INITRAMFS)/hooks/wireguard"
-	@cp -v init-premount "$(INITRAMFS)/scripts/init-premount/wireguard"
-	@chmod 0755 init-premount "$(INITRAMFS)/scripts/init-premount/wireguard"
-	@cp -v init-bottom "$(INITRAMFS)/scripts/init-bottom/wireguard"
-	@chmod 0755 init-bottom "$(INITRAMFS)/scripts/init-bottom/wireguard"
-	-@mkdir -p "$(DOCSDIR)/examples"
-	@chmod -R 0755 "$(DOCSDIR)"
-	@cp -v config "$(DOCSDIR)/examples/config"
-	@chmod 0644 "$(DOCSDIR)/examples/config"
+	@install -vD hooks "$(INITRAMFS)/hooks/wireguard"
+	@install -vD init-premount "$(INITRAMFS)/scripts/init-premount/wireguard"
+	@install -vD init-bottom "$(INITRAMFS)/scripts/init-bottom/wireguard"
+	@install -vD -m0644 config "$(DOCSDIR)/examples/config"
 
 .PHONY: install
 install: root_check remove_legacy install_deps

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,12 @@ help:
 	@echo "Example configuration located at: $(DOCSDIR)"
 	@echo
 
-.PHONY: install
-install: remove_legacy
+.PHONY: root_check
+root_check:
 	@if ! [ "$(shell id -u)" = 0 ]; then echo "You must be root to perform this action."; exit 1; fi
+
+.PHONY: install
+install: root_check remove_legacy
 	@echo "Installing wireguard-initramfs ..."
 	@apt update && apt install initramfs-tools
 	@mkdir -p "$(TARGETDIR)"
@@ -49,8 +52,7 @@ install: remove_legacy
 	@echo "Done."
 
 .PHONY: uninstall
-uninstall: remove_legacy
-	@if ! [ "$(shell id -u)" = 0 ]; then echo "You must be root to perform this action."; exit 1; fi
+uninstall: root_check remove_legacy
 	@echo "Uninstalling wireguard-initramfs ..."
 	@rm -f "$(INITRAMFS)/hooks/wireguard"
 	@rm -f "$(INITRAMFS)/scripts/init-premount/wireguard"
@@ -60,7 +62,7 @@ uninstall: remove_legacy
 	@echo "Done."
 
 .PHONY: remove_legacy
-remove_legacy:
+remove_legacy: root_check
 	@rm -f "/usr/share/initramfs-tools/hooks/wireguard"
 	@rm -f "/usr/share/initramfs-tools/scripts/init-premount/wireguard"
 	@rm -f "/usr/share/initramfs-tools/scripts/init-bottom/wireguard"

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ help:
 	@echo "Example configuration located at: $(DOCSDIR)"
 	@echo
 
-.PHONY: help Makefile
+.PHONY: help 
 
 install: remove_legacy
 	@if ! [ "$(shell id -u)" = 0 ]; then echo "You must be root to perform this action."; exit 1; fi

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ TARGETDIR = $(DESTDIR)/etc/wireguard-initramfs
 INITRAMFS = $(DESTDIR)/etc/initramfs-tools
 DOCSDIR   = $(DESTDIR)/usr/local/share/docs/wireguard-initramfs
 
+.PHONY: help 
 help:
 	@echo "USAGE:"
 	@echo "  make install"
@@ -17,8 +18,7 @@ help:
 	@echo "Example configuration located at: $(DOCSDIR)"
 	@echo
 
-.PHONY: help 
-
+.PHONY: install
 install: remove_legacy
 	@if ! [ "$(shell id -u)" = 0 ]; then echo "You must be root to perform this action."; exit 1; fi
 	@echo "Installing wireguard-initramfs ..."
@@ -48,6 +48,7 @@ install: remove_legacy
 	@echo
 	@echo "Done."
 
+.PHONY: uninstall
 uninstall: remove_legacy
 	@if ! [ "$(shell id -u)" = 0 ]; then echo "You must be root to perform this action."; exit 1; fi
 	@echo "Uninstalling wireguard-initramfs ..."
@@ -58,6 +59,7 @@ uninstall: remove_legacy
 	@echo
 	@echo "Done."
 
+.PHONY: remove_legacy
 remove_legacy:
 	@rm -f "/usr/share/initramfs-tools/hooks/wireguard"
 	@rm -f "/usr/share/initramfs-tools/scripts/init-premount/wireguard"

--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,12 @@ help:
 root_check:
 	@if ! [ "$(shell id -u)" = 0 ]; then echo "You must be root to perform this action."; exit 1; fi
 
-.PHONY: install
-install: root_check remove_legacy
-	@echo "Installing wireguard-initramfs ..."
+.PHONY: install_deps
+install_deps: root_check
 	@apt update && apt install initramfs-tools
+
+.PHONY: install_files
+install_files:
 	@mkdir -p "$(TARGETDIR)"
 	@touch "$(TARGETDIR)/private_key"
 	@chmod 0600 "$(TARGETDIR)/private_key"
@@ -43,6 +45,11 @@ install: root_check remove_legacy
 	@chmod -R 0755 "$(DOCSDIR)"
 	@cp -v config "$(DOCSDIR)/examples/config"
 	@chmod 0644 "$(DOCSDIR)/examples/config"
+
+.PHONY: install
+install: root_check remove_legacy install_deps
+	@echo "Installing wireguard-initramfs ..."
+	+$(MAKE) install_files
 	@echo "Done."
 	@echo
 	@echo "Setup $(TARGETDIR)/config and run:"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Makefile for wireguard initramfs boot.
 
-TARGETDIR = /etc/wireguard-initramfs
-INITRAMFS = /etc/initramfs-tools
-DOCSDIR   = /usr/local/share/docs/wireguard-initramfs
+TARGETDIR = $(DESTDIR)/etc/wireguard-initramfs
+INITRAMFS = $(DESTDIR)/etc/initramfs-tools
+DOCSDIR   = $(DESTDIR)/usr/local/share/docs/wireguard-initramfs
 
 help:
 	@echo "USAGE:"


### PR DESCRIPTION
This are some small enhancements for the Makefile. With this change it will be much easier to create an official debian package.

This should not lead to functional differences for the normal users, but now it is possible to call something like `make install_files DESTDIR=debian/tmp` during the build process of the debian package.